### PR TITLE
Do not emit control characters in title reports

### DIFF
--- a/src/ConEmuCD/ConAnsiImpl.cpp
+++ b/src/ConEmuCD/ConAnsiImpl.cpp
@@ -985,7 +985,7 @@ bool SrvAnsiImpl::ReportString(LPCWSTR asRet)
 	LPCWSTR pc = asRet;
 	for (int i = 0; i < nLen; i++, p++, pc++)
 	{
-		const char ch = (wcschr(UNSAFE_CONSOLE_REPORT_CHARS, *pc) == nullptr) ? *pc : L' ';
+		const char ch = *pc >= 0x20 ? *pc : L' ';
 		p->EventType = KEY_EVENT;
 		p->Event.KeyEvent.bKeyDown = TRUE;
 		p->Event.KeyEvent.wRepeatCount = 1;

--- a/src/ConEmuHk/Ansi.cpp
+++ b/src/ConEmuHk/Ansi.cpp
@@ -2505,7 +2505,7 @@ BOOL CEAnsi::ReportString(LPCWSTR asRet)
 	LPCWSTR pc = asRet;
 	for (size_t i = 0; i < nLen; i++, p++, pc++)
 	{
-		const char ch = (wcschr(UNSAFE_CONSOLE_REPORT_CHARS, *pc) == nullptr) ? *pc : L' ';
+		const char ch = *pc >= 0x20 ? *pc : L' ';
 		p->EventType = KEY_EVENT;
 		p->Event.KeyEvent.bKeyDown = TRUE;
 		p->Event.KeyEvent.wRepeatCount = 1;

--- a/src/common/WConsole.h
+++ b/src/common/WConsole.h
@@ -52,9 +52,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DISABLE_NEWLINE_AUTO_RETURN 0x0008
 #endif
 
-// These keys should not be reported back to console input
-#define UNSAFE_CONSOLE_REPORT_CHARS L"\r\n\t"
-
 struct MY_CONSOLE_SCREEN_BUFFER_INFOEX
 {
 	ULONG      cbSize;


### PR DESCRIPTION
<!--
### Description

This PR is a security feature for the ConEmu terminal, that fixes an issue where a malicious title report escape sequence could execute arbitrary commands on the terminal.

The issue is caused by the fact that ConEmu emits any characters in the title to the terminal when a title report escape sequence (`\e[21t`) is executed. If the title contains control characters, such as new line, they could be interpreted as commands by the shell or other programs.

For example, if the title is set to `Hello\nrm -rf /`, then executing a title report escape sequence would result in deleting all files on the root directory.

Previously, the author only disabled whitespace characters from being reported. This is not sufficient, as there are other control characters that could cause harm, such as `\e`, `\b`, etc.

This PR disables all control characters from being reported, by making sure the character point is equal or greater than hex code `0x20`. This way, only printable characters are emitted to the terminal, and any potential malicious commands are avoided.

More information about this issue can be found here: https://seclists.org/fulldisclosure/2003/Feb/341
-->
